### PR TITLE
ci: fix workflow triggers and helm install

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -145,39 +145,3 @@ jobs:
           echo "Largest directories:"
           du -sh * 2>/dev/null | sort -hr | head -10 || true
 
-  cleanup-phos-ci-runs:
-    name: Cleanup PHOS CI workflow runs (older than 30 days)
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Install GitHub CLI
-        run: |
-          if ! command -v gh >/dev/null 2>&1; then
-            type -p unzip >/dev/null || (sudo apt-get update -y && sudo apt-get install -y unzip)
-            curl -fsSL https://github.com/cli/cli/releases/download/v2.55.0/gh_2.55.0_linux_amd64.tar.gz -o /tmp/gh.tar.gz
-            sudo tar -C /usr/local -xzf /tmp/gh.tar.gz --strip-components=1 gh_2.55.0_linux_amd64/bin/gh
-          fi
-      - name: Delete old runs for phos-ci.yml
-        id: delete_runs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          cutoff=$(date -u -d '30 days ago' +%s)
-          runs=$(gh run list --workflow phos-ci.yml --limit 1000 --json databaseId,createdAt --jq '.[] | [.databaseId, .createdAt] | @tsv')
-          deleted=0
-          while IFS=$'\t' read -r id created; do
-            [[ -z "${id:-}" ]] && continue
-            created_epoch=$(date -u -d "$created" +%s)
-            if [ "$created_epoch" -lt "$cutoff" ]; then
-              echo "Deleting run $id (created $created)"
-              gh run delete "$id" --yes || true
-              deleted=$((deleted+1))
-            fi
-          done <<< "$runs"
-          echo "deleted=$deleted" >> "$GITHUB_OUTPUT"
-      - name: Output number of deleted runs
-        run: echo "Deleted ${{ steps.delete_runs.outputs.deleted }} workflow runs older than 30 days"

--- a/.github/workflows/phos-ci.yml
+++ b/.github/workflows/phos-ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [ 'main' ]
   pull_request:
-    branches: [ 'main' ]
+    branches:
+      - main
+      - chore/infra-disable-legacy-web-patient-app
   workflow_dispatch:
 
 jobs:
@@ -115,10 +117,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.14.4
+      - name: Install Helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Lint charts
         run: |
           helm lint charts/* || (echo "Helm lint failed" && exit 1)


### PR DESCRIPTION
## Summary
- install Helm using official script
- run CI on pull requests targeting `main` and `chore/infra-disable-legacy-web-patient-app`
- remove cleanup job that used `gh run list`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/Ojala-healthcare_new/scripts/dist/cleanup-empty.js')*
- `npx jest` *(fails: Need to install the following packages: jest@30.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b3478fdac4832786d05493d154bedb